### PR TITLE
add query str support to display-page helper

### DIFF
--- a/dash_router/__init__.py
+++ b/dash_router/__init__.py
@@ -2,6 +2,7 @@ from werkzeug.routing import Map, Rule, NotFound, RequestRedirect
 import dash
 import dash_html_components as html
 import dash_core_components as dcc
+from urllib import parse
 
 
 class Router:
@@ -41,10 +42,15 @@ class Router:
         dashapp.layout = self.layout
         @dashapp.callback(
             dash.dependencies.Output('page-content', 'children'),
-            [dash.dependencies.Input('url', 'pathname')]
+            [dash.dependencies.Input('url', 'pathname')],
+            [dash.dependencies.State("url", "search")],
         )
-        def display_page(pathname):
-            return self.dispatch(pathname)        
+        def display_page(pathname: str, search: str = None):
+            if search:
+                query_dict = dict(parse.parse_qsl(search[1:]))
+                return self.dispatch(pathname, **query_dict)
+            else:
+                return self.dispatch(pathname)    
 
     def dispatch(self, path, **kwargs):
         if path is None:

--- a/dash_router/__init__.py
+++ b/dash_router/__init__.py
@@ -6,7 +6,7 @@ from urllib import parse
 
 
 class Router:
-    def __init__(self, server_name='', layout=None, loading=None, not_found=None):
+    def __init__(self, server_name="", layout=None, loading=None, not_found=None):
         self.server_name = server_name
         self.url_map = Map()
         self.view_functions = {}
@@ -14,20 +14,22 @@ class Router:
 
     def _set_default_templates(self, layout, loading, not_found):
         if layout is None:
-            self.layout = html.Div([
-                dcc.Location(id='url', refresh=False),
-                html.Div(id='page-content'),
-            ])
+            self.layout = html.Div(
+                [
+                    dcc.Location(id="url", refresh=False),
+                    html.Div(id="page-content"),
+                ]
+            )
         else:
             self.layout = layout
         if loading is None:
-            self.loading = 'Loading...'
+            self.loading = "Loading..."
         else:
             self.loading = loading
         if not_found is None:
-            self.not_found = html.Div([
-                html.P(["404 Page not found"])
-            ], className="no-page")
+            self.not_found = html.Div(
+                [html.P(["404 Page not found"])], className="no-page"
+            )
         else:
             self.not_found = not_found
 
@@ -40,22 +42,25 @@ class Router:
     def register_callbacks(self, dashapp):
         # Helper that includes basic layout and wires up callback
         dashapp.layout = self.layout
+
         @dashapp.callback(
-            dash.dependencies.Output('page-content', 'children'),
-            [dash.dependencies.Input('url', 'pathname')],
-            [dash.dependencies.State("url", "search")],
+            dash.dependencies.Output("page-content", "children"),
+            [
+                dash.dependencies.Input("url", "pathname"),
+            ],
         )
-        def display_page(pathname: str, search: str = None):
-            if search:
+        def display_page(pathname: str):
+            if "?" in pathname:
+                pathname, search = pathname.split("?")
                 query_dict = dict(parse.parse_qsl(search[1:]))
                 return self.dispatch(pathname, **query_dict)
             else:
-                return self.dispatch(pathname)    
+                return self.dispatch(pathname)
 
     def dispatch(self, path, **kwargs):
         if path is None:
             return self.loading
-        ma = self.url_map.bind(server_name=self.server_name)        
+        ma = self.url_map.bind(server_name=self.server_name)
         try:
             endpoint, kwards = ma.match(path)
             return self.view_functions[endpoint](**kwards, **kwargs)
@@ -65,7 +70,7 @@ class Router:
     def add_url_rule(self, rule, endpoint=None, view_func=None, **options):
         if endpoint is None:
             endpoint = view_func.__name__
-        options["endpoint"] = endpoint 
+        options["endpoint"] = endpoint
         methods = ("GET", "POST")
 
         rule = Rule(rule, methods=methods, **options)
@@ -76,7 +81,7 @@ class Router:
                 raise AssertionError(
                     "View function mapping is overwriting an "
                     "existing endpoint function: %s" % endpoint
-                )        
+                )
             self.view_functions[endpoint] = view_func
 
     def route(self, rule, **options):
@@ -84,4 +89,5 @@ class Router:
             endpoint = options.pop("endpoint", None)
             self.add_url_rule(rule, endpoint, f, **options)
             return f
+
         return decorator


### PR DESCRIPTION
based on the example given by @scott-arne, add support to query strings in the register callbacks helper.

Just add `**kwargs` to the endpoint:

```
@router.route("/qs-example/<required_arg>")
def qs_endpoint(required_arg, **kwargs):
    return html.H1(f"{required_arg}, {kwargs}")```